### PR TITLE
Fill in remaining src and pkg pages to fix links

### DIFF
--- a/gopages/cmd/demo/main.go
+++ b/gopages/cmd/demo/main.go
@@ -2,12 +2,31 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/johnstarich/go/gopages/internal/flags"
+	"github.com/johnstarich/go/gopages/internal/generate"
+	"github.com/johnstarich/go/gopages/internal/pipe"
+	"github.com/pkg/errors"
+	"golang.org/x/mod/modfile"
 )
 
 func main() {
-	fs := http.Dir("dist")
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	fs, err := pagesFileSystem(wd)
+	if err != nil {
+		panic(err)
+	}
 	fileServer := http.FileServer(fs)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -36,4 +55,68 @@ func main() {
 	}
 	fmt.Println("Starting demo server on :8080...")
 	_ = server.ListenAndServe()
+}
+
+func pagesFileSystem(modulePath string) (http.FileSystem, error) {
+	src := osfs.New("")
+	fs := memfs.New()
+
+	goMod := filepath.Join(modulePath, "go.mod")
+	var modulePackage string
+	err := pipe.ChainFuncs(
+		func() error {
+			_, err := os.Stat(goMod)
+			return pipe.ErrIf(os.IsNotExist(err), errors.New("go.mod not found in the current directory"))
+		},
+		func() error {
+			buf, err := ioutil.ReadFile(goMod)
+			modulePackage = modfile.ModulePath(buf)
+			return err
+		},
+		func() error {
+			return pipe.ErrIf(modulePackage == "", errors.Errorf("Unable to find module package name in go.mod file: %s", goMod))
+		},
+		func() error {
+			return generate.Docs(modulePath, modulePackage, src, fs, flags.Args{})
+		},
+	).Do()
+	return &httpFSWrapper{fs}, err
+}
+
+type httpFSWrapper struct {
+	billy.Filesystem
+}
+
+func (h *httpFSWrapper) Open(name string) (http.File, error) {
+	info, err := h.Filesystem.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var file billy.File
+	if info.IsDir() {
+		file, err = memfs.New().Create(name)
+	} else {
+		file, err = h.Filesystem.Open(name)
+	}
+	return &httpFileWrapper{
+		File: file,
+		fs:   h.Filesystem,
+		name: name,
+	}, err
+}
+
+type httpFileWrapper struct {
+	billy.File
+
+	name string
+	fs   billy.Filesystem
+}
+
+func (h *httpFileWrapper) Readdir(count int) ([]os.FileInfo, error) {
+	return h.fs.ReadDir(h.name)
+}
+
+func (h *httpFileWrapper) Stat() (os.FileInfo, error) {
+	return h.fs.Stat(h.name)
 }

--- a/gopages/cmd/watch/main.go
+++ b/gopages/cmd/watch/main.go
@@ -1,7 +1,7 @@
 // Command watch generates docs and starts an HTTP endpoint to serve them. Also runs a file watcher on the current module to regenerate docs on change events.
 //
 // watch is useful for testing godoc code comments and while developing on gopages itself.
-// Accepts the same flags as gopages.
+// Accepts the same flags as gopages, -gh-pages flags are ignored.
 package main
 
 import (

--- a/gopages/cmd/watch/watch.go
+++ b/gopages/cmd/watch/watch.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func watch(ctx context.Context, path string, do func() error) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return watcher.Add(path)
+		}
+		return nil
+	})
+	if err != nil {
+		watcher.Close()
+		return err
+	}
+
+	go func() {
+		timer := time.NewTimer(0) // fire watch right away
+		defer timer.Stop()
+
+		const debounce = 2 * time.Second
+		for {
+			select {
+			case <-timer.C:
+				log.Println("Running watch call...")
+				err := do()
+				if err != nil {
+					log.Println("Error running watch call:", err)
+				}
+			case <-ctx.Done():
+				watcher.Close()
+				return
+			case event := <-watcher.Events:
+				switch {
+				case event.Op&fsnotify.Write == fsnotify.Write,
+					event.Op&fsnotify.Create == fsnotify.Create:
+					timer.Reset(debounce)
+				}
+			case err := <-watcher.Errors:
+				log.Println("error:", err)
+			}
+		}
+	}()
+	return nil
+}

--- a/gopages/go.mod
+++ b/gopages/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/mod v0.3.0
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e
 )

--- a/gopages/go.mod
+++ b/gopages/go.mod
@@ -3,6 +3,7 @@ module github.com/johnstarich/go/gopages
 go 1.13
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.0.0
 	github.com/pkg/errors v0.9.1

--- a/gopages/go.sum
+++ b/gopages/go.sum
@@ -16,6 +16,7 @@ github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
+github.com/go-git/go-billy v4.2.0+incompatible h1:Z6QtVXd5tjxUtcODLugkJg4WaZnGg13CD8qB9pr+7q0=
 github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=
 github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=

--- a/gopages/go.sum
+++ b/gopages/go.sum
@@ -12,6 +12,8 @@ github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -71,6 +73,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/gopages/internal/flags/flags.go
+++ b/gopages/internal/flags/flags.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 )
 
+// Args contains all command-line options for gopages
 type Args struct {
 	BaseURL          string
 	GitHubPages      bool

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -149,7 +149,7 @@ func doRequest(do func(w http.ResponseWriter)) ([]byte, error) {
 	do(recorder)
 	return recorder.Body.Bytes(), pipe.ErrIf(
 		recorder.Result().StatusCode != http.StatusOK,
-		errors.Errorf("Error generating page: [%d]\n%s", recorder.Result().StatusCode, recorder.Body.String()),
+		errors.Errorf("Error generating page: [%d]\n%s\n%s", recorder.Result().StatusCode, recorder.Header(), recorder.Body.String()),
 	)
 }
 

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -58,6 +58,13 @@ func Docs(modulePath, modulePackage string, src, fs billy.Filesystem, args flags
 	}
 
 	pres := godoc.NewPresentation(corpus)
+	pres.AdjustPageInfoMode = func(req *http.Request, mode godoc.PageInfoMode) godoc.PageInfoMode {
+		switch {
+		case req.URL.Path == "/pkg/", strings.HasPrefix(req.URL.Path, "/pkg/") && strings.HasSuffix(req.URL.Path, "/internal/"):
+			mode |= godoc.NoFiltering
+		}
+		return mode
+	}
 	// attempt to override URLs for source code links
 	// TODO fix links from source pages back to docs
 	pres.URLForSrc = func(src string) string {
@@ -238,7 +245,7 @@ func writePackageIndex(fs billy.Filesystem, pres *godoc.Presentation, packagePat
 	return pipe.ChainFuncs(
 		func() error {
 			var err error
-			page, err = getPage(pres, path.Join("/pkg", packagePath)+"/?m=all") // show index pages for internal packages
+			page, err = getPage(pres, path.Join("/pkg", packagePath)+"/")
 			return err
 		},
 		func() error {

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -138,7 +138,7 @@ Oops, this page doesn't exist.
 					return nil
 				}
 				dir, base := filepath.Split(file)
-				return writeSourceFile(fs, pres, path.Join(modulePackage, dir), base, args.OutputPath)
+				return writeSourceFile(fs, pres, args.BaseURL, path.Join(modulePackage, dir), base, args.OutputPath)
 			})
 		},
 	).Do()
@@ -198,7 +198,7 @@ func writePackageIndex(fs billy.Filesystem, pres *godoc.Presentation, packagePat
 	).Do()
 }
 
-func writeSourceFile(fs billy.Filesystem, pres *godoc.Presentation, packagePath, fileName, outputBasePath string) error {
+func writeSourceFile(fs billy.Filesystem, pres *godoc.Presentation, baseURL, packagePath, fileName, outputBasePath string) error {
 	outputComponents := append([]string{outputBasePath, "src"}, pathSplit(packagePath)...)
 	outputComponents = append(outputComponents, fileName)
 	outputPath := filepath.Join(outputComponents...) + ".html"
@@ -208,6 +208,11 @@ func writeSourceFile(fs billy.Filesystem, pres *godoc.Presentation, packagePath,
 		func() error {
 			var err error
 			page, err = getPage(pres, path.Join("/src", packagePath, fileName))
+			return err
+		},
+		func() error {
+			var err error
+			page, err = customizeSourceCodePage(baseURL, page)
 			return err
 		},
 		func() error {

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -1,4 +1,4 @@
-package main
+package generate
 
 import (
 	"bytes"
@@ -23,70 +23,7 @@ import (
 	"golang.org/x/tools/godoc/vfs/mapfs"
 )
 
-func readTemplates(pres *godoc.Presentation, funcs template.FuncMap, fs vfs.FileSystem) {
-	pres.CallGraphHTML = readTemplate(funcs, fs, "callgraph.html")
-	pres.DirlistHTML = readTemplate(funcs, fs, "dirlist.html")
-	pres.ErrorHTML = readTemplate(funcs, fs, "error.html")
-	pres.ExampleHTML = readTemplate(funcs, fs, "example.html")
-	pres.GodocHTML = parseTemplate(funcs, "godoc.html", godocHTML)
-	pres.ImplementsHTML = readTemplate(funcs, fs, "implements.html")
-	pres.MethodSetHTML = readTemplate(funcs, fs, "methodset.html")
-	pres.PackageHTML = readTemplate(funcs, fs, "package.html")
-	pres.PackageRootHTML = readTemplate(funcs, fs, "packageroot.html")
-}
-
-func readTemplate(funcs template.FuncMap, fs vfs.FileSystem, name string) *template.Template {
-	// use underlying file system fs to read the template file
-	// (cannot use template ParseFile functions directly)
-	data, err := vfs.ReadFile(fs, path.Join("lib/godoc", name))
-	if err != nil {
-		panic(err)
-	}
-	return parseTemplate(funcs, name, string(data))
-}
-
-func parseTemplate(funcs template.FuncMap, name, data string) *template.Template {
-	t, err := template.New(name).Funcs(funcs).Parse(data)
-	if err != nil {
-		panic(err)
-	}
-	return t
-}
-
-func addGoPagesFuncs(funcs template.FuncMap, args flags.Args) {
-	var longTitle string
-	if args.SiteTitle != "" && args.SiteDescription != "" {
-		longTitle = fmt.Sprintf("%s | %s", args.SiteTitle, args.SiteDescription)
-	}
-	values := map[string]interface{}{
-		"BaseURL":       args.BaseURL,
-		"SiteTitle":     args.SiteTitle,
-		"SiteTitleLong": longTitle,
-	}
-	funcs["gopages"] = func(defaultValue, firstKey string, keys ...string) (string, error) {
-		keys = append([]string{firstKey}, keys...) // require at least one key
-		for _, key := range keys {
-			value, ok := values[key]
-			var valueStr string
-			err := pipe.ChainFuncs(
-				func() error {
-					return pipe.ErrIf(!ok, errors.Errorf("Unknown gopages key: %q", key))
-				},
-				func() error {
-					var isString bool
-					valueStr, isString = value.(string)
-					return pipe.ErrIf(!isString, errors.Errorf("gopages key %q is not a string", key))
-				},
-			).Do()
-			if err != nil || valueStr != "" {
-				return template.HTMLEscapeString(valueStr), err
-			}
-		}
-		return defaultValue, nil
-	}
-}
-
-func generateDocs(modulePath, modulePackage string, args flags.Args, src, fs billy.Filesystem) error {
+func Docs(modulePath, modulePackage string, src, fs billy.Filesystem, args flags.Args) error {
 	var ns vfs.NameSpace
 	var srcRoot billy.Filesystem
 	var corpus *godoc.Corpus

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -85,7 +85,7 @@ func Docs(modulePath, modulePackage string, src, fs billy.Filesystem, args flags
 		}).String()
 	}
 	funcs := pres.FuncMap()
-	addGoPagesFuncs(funcs, args)
+	addGoPagesFuncs(funcs, modulePackage, args)
 	readTemplates(pres, funcs, ns)
 
 	// Generate all static assets and save to /lib/godoc

--- a/gopages/internal/generate/generate_test.go
+++ b/gopages/internal/generate/generate_test.go
@@ -1,4 +1,4 @@
-package main
+package generate
 
 import (
 	"io/ioutil"
@@ -55,7 +55,7 @@ func Hello() {
 `)
 
 	args := flags.Args{}
-	err = generateDocs(thing, "thing", args, thingFS, outputFS)
+	err = Docs(thing, "thing", thingFS, outputFS, args)
 	assert.NoError(t, err)
 
 	expectedDocs := []string{

--- a/gopages/internal/generate/generate_test.go
+++ b/gopages/internal/generate/generate_test.go
@@ -53,6 +53,9 @@ func Hello() {
 	println("Hello world")
 }
 `)
+	writeFile("mylib/lib.go", `
+package mylib
+`)
 	writeFile(".git/something", `ignored dot dir`)
 	writeFile(".dotfile", `ignored dot file`)
 
@@ -68,6 +71,7 @@ func Hello() {
 		"pkg/github.com/my/thing/index.html",
 		"pkg/github.com/my/thing/internal/hello/index.html",
 		"pkg/github.com/my/thing/internal/index.html",
+		"pkg/github.com/my/thing/mylib/index.html",
 		"pkg/index.html",
 		"src/github.com/index.html",
 		"src/github.com/my/index.html",
@@ -76,6 +80,8 @@ func Hello() {
 		"src/github.com/my/thing/internal/hello/index.html",
 		"src/github.com/my/thing/internal/index.html",
 		"src/github.com/my/thing/main.go.html",
+		"src/github.com/my/thing/mylib/index.html",
+		"src/github.com/my/thing/mylib/lib.go.html",
 		"src/index.html",
 	}
 	var foundDocs []string
@@ -92,5 +98,5 @@ func Hello() {
 	require.NoError(t, err)
 	indexContents, err := ioutil.ReadAll(f)
 	require.NoError(t, err)
-	assert.Contains(t, string(indexContents), "internal/hello")
+	assert.Contains(t, string(indexContents), "mylib")
 }

--- a/gopages/internal/generate/godoc.html.go
+++ b/gopages/internal/generate/godoc.html.go
@@ -1,4 +1,4 @@
-package main
+package generate
 
 const (
 	godocHTML = `<!DOCTYPE html>

--- a/gopages/internal/generate/godoc.html.go
+++ b/gopages/internal/generate/godoc.html.go
@@ -36,8 +36,8 @@ const (
 </div><!-- #lowframe -->
 
 <div id="topbar"{{if .Title}} class="wide"{{end}}><div class="container">
-<div class="top-heading" id="heading-wide"><a href="{{gopages "" "BaseURL"}}/pkg/">{{gopages "GoPages | Auto-generated docs" "SiteTitleLong" "SiteTitle"}}</a></div>
-<div class="top-heading" id="heading-narrow"><a href="{{gopages "" "BaseURL"}}/pkg/">{{gopages "GoPages" "SiteTitle"}}</a></div>
+<div class="top-heading" id="heading-wide"><a href="{{gopages "" "ModuleURL"}}">{{gopages "GoPages | Auto-generated docs" "SiteTitleLong" "SiteTitle"}}</a></div>
+<div class="top-heading" id="heading-narrow"><a href="{{gopages "" "ModuleURL"}}">{{gopages "GoPages" "SiteTitle"}}</a></div>
 <a href="#" id="menu-button"><span id="menu-button-arrow">&#9661;</span></a>
 
 </div></div>

--- a/gopages/internal/generate/source.go
+++ b/gopages/internal/generate/source.go
@@ -1,0 +1,56 @@
+package generate
+
+import (
+	"bytes"
+	"path"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// customizeSourceCodePage re-renders the given source code page's HTML with fixed links and content.
+// This is necessary because the source HTML is only generated in private functions inside godoc.
+// * Prepends baseURL to all links.
+// * Removes "View as plain text", since the generated link only adds a query param to the same page.
+func customizeSourceCodePage(baseURL string, page []byte) ([]byte, error) {
+	node, err := html.Parse(bytes.NewReader(page))
+	if err != nil {
+		return nil, err
+	}
+
+	addBaseURL(baseURL, node)
+	removeViewAsPlainText(node)
+
+	var buf bytes.Buffer
+	err = html.Render(&buf, node)
+	return buf.Bytes(), err
+}
+
+func removeViewAsPlainText(node *html.Node) (deleteNode bool) {
+	if node.Type == html.ElementNode && node.Data == "a" &&
+		node.FirstChild != nil && node.FirstChild.Type == html.TextNode && node.FirstChild.Data == "View as plain text" {
+		return true
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		shouldRemove := removeViewAsPlainText(child)
+		if shouldRemove {
+			node.RemoveChild(child)
+		}
+	}
+	return false
+}
+
+func addBaseURL(baseURL string, node *html.Node) {
+	if node.Type == html.ElementNode && node.Data == "a" {
+		for i := range node.Attr {
+			attr := &node.Attr[i]
+			if attr.Key == "href" && strings.HasPrefix(attr.Val, "/") {
+				attr.Val = path.Join(baseURL, attr.Val)
+				break
+			}
+		}
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		addBaseURL(baseURL, child)
+	}
+}

--- a/gopages/internal/generate/source.go
+++ b/gopages/internal/generate/source.go
@@ -44,7 +44,7 @@ func addBaseURL(baseURL string, node *html.Node) {
 	if node.Type == html.ElementNode && node.Data == "a" {
 		for i := range node.Attr {
 			attr := &node.Attr[i]
-			if attr.Key == "href" && strings.HasPrefix(attr.Val, "/") {
+			if attr.Key == "href" && strings.HasPrefix(attr.Val, "/") && !strings.HasPrefix(attr.Val, baseURL) {
 				attr.Val = path.Join(baseURL, attr.Val)
 				break
 			}

--- a/gopages/internal/generate/template.go
+++ b/gopages/internal/generate/template.go
@@ -1,0 +1,76 @@
+package generate
+
+import (
+	"fmt"
+	"path"
+	"text/template"
+
+	"github.com/johnstarich/go/gopages/internal/flags"
+	"github.com/johnstarich/go/gopages/internal/pipe"
+	"github.com/pkg/errors"
+	"golang.org/x/tools/godoc"
+	"golang.org/x/tools/godoc/vfs"
+)
+
+func addGoPagesFuncs(funcs template.FuncMap, args flags.Args) {
+	var longTitle string
+	if args.SiteTitle != "" && args.SiteDescription != "" {
+		longTitle = fmt.Sprintf("%s | %s", args.SiteTitle, args.SiteDescription)
+	}
+	values := map[string]interface{}{
+		"BaseURL":       args.BaseURL,
+		"SiteTitle":     args.SiteTitle,
+		"SiteTitleLong": longTitle,
+	}
+	funcs["gopages"] = func(defaultValue, firstKey string, keys ...string) (string, error) {
+		keys = append([]string{firstKey}, keys...) // require at least one key
+		for _, key := range keys {
+			value, ok := values[key]
+			var valueStr string
+			err := pipe.ChainFuncs(
+				func() error {
+					return pipe.ErrIf(!ok, errors.Errorf("Unknown gopages key: %q", key))
+				},
+				func() error {
+					var isString bool
+					valueStr, isString = value.(string)
+					return pipe.ErrIf(!isString, errors.Errorf("gopages key %q is not a string", key))
+				},
+			).Do()
+			if err != nil || valueStr != "" {
+				return template.HTMLEscapeString(valueStr), err
+			}
+		}
+		return defaultValue, nil
+	}
+}
+
+func readTemplates(pres *godoc.Presentation, funcs template.FuncMap, fs vfs.FileSystem) {
+	pres.CallGraphHTML = readTemplate(funcs, fs, "callgraph.html")
+	pres.DirlistHTML = readTemplate(funcs, fs, "dirlist.html")
+	pres.ErrorHTML = readTemplate(funcs, fs, "error.html")
+	pres.ExampleHTML = readTemplate(funcs, fs, "example.html")
+	pres.GodocHTML = parseTemplate(funcs, "godoc.html", godocHTML)
+	pres.ImplementsHTML = readTemplate(funcs, fs, "implements.html")
+	pres.MethodSetHTML = readTemplate(funcs, fs, "methodset.html")
+	pres.PackageHTML = readTemplate(funcs, fs, "package.html")
+	pres.PackageRootHTML = readTemplate(funcs, fs, "packageroot.html")
+}
+
+func readTemplate(funcs template.FuncMap, fs vfs.FileSystem, name string) *template.Template {
+	// use underlying file system fs to read the template file
+	// (cannot use template ParseFile functions directly)
+	data, err := vfs.ReadFile(fs, path.Join("lib/godoc", name))
+	if err != nil {
+		panic(err)
+	}
+	return parseTemplate(funcs, name, string(data))
+}
+
+func parseTemplate(funcs template.FuncMap, name, data string) *template.Template {
+	t, err := template.New(name).Funcs(funcs).Parse(data)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/gopages/internal/generate/template.go
+++ b/gopages/internal/generate/template.go
@@ -12,13 +12,14 @@ import (
 	"golang.org/x/tools/godoc/vfs"
 )
 
-func addGoPagesFuncs(funcs template.FuncMap, args flags.Args) {
+func addGoPagesFuncs(funcs template.FuncMap, modulePackage string, args flags.Args) {
 	var longTitle string
 	if args.SiteTitle != "" && args.SiteDescription != "" {
 		longTitle = fmt.Sprintf("%s | %s", args.SiteTitle, args.SiteDescription)
 	}
 	values := map[string]interface{}{
 		"BaseURL":       args.BaseURL,
+		"ModuleURL":     path.Join(args.BaseURL, "pkg", modulePackage) + "/",
 		"SiteTitle":     args.SiteTitle,
 		"SiteTitleLong": longTitle,
 	}

--- a/gopages/internal/safememfs/memfs.go
+++ b/gopages/internal/safememfs/memfs.go
@@ -1,0 +1,33 @@
+// Package safememfs wraps go-billy/memfs's Open to correctly handle opening directories
+package safememfs
+
+import (
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+)
+
+// New creates a new billy/memfs file system that can handle opening directories
+func New() billy.Filesystem {
+	fs := memfs.New()
+	return &safeOpener{fs}
+}
+
+type safeOpener struct {
+	billy.Filesystem
+}
+
+func (s *safeOpener) Open(name string) (billy.File, error) {
+	info, err := s.Filesystem.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var file billy.File
+	// memfs.Open doesn't work for directories, so create a false dir for those instead
+	if info.IsDir() {
+		file, err = memfs.New().Create(name)
+	} else {
+		file, err = s.Filesystem.Open(name)
+	}
+	return file, err
+}

--- a/gopages/main.go
+++ b/gopages/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/johnstarich/go/gopages/cmd"
 	"github.com/johnstarich/go/gopages/internal/flags"
+	"github.com/johnstarich/go/gopages/internal/generate"
 	"github.com/johnstarich/go/gopages/internal/pipe"
 	"github.com/pkg/errors"
 	"golang.org/x/mod/modfile"
@@ -87,7 +88,7 @@ func run(modulePath string, args flags.Args) error {
 
 	if !args.GitHubPages {
 		fs := osfs.New("")
-		return generateDocs(modulePath, modulePackage, args, fs, fs)
+		return generate.Docs(modulePath, modulePackage, fs, fs, args)
 	}
 
 	var repoRoot, remote string
@@ -138,7 +139,7 @@ func run(modulePath string, args flags.Args) error {
 			return nil
 		},
 		func() error {
-			return generateDocs(modulePath, modulePackage, args, src, fs)
+			return generate.Docs(modulePath, modulePackage, src, fs, args)
 		},
 	).Do()
 	if err != nil {

--- a/gopages/main_test.go
+++ b/gopages/main_test.go
@@ -204,8 +204,12 @@ func Hello() {
 			assert.Equal(t, []string{
 				"404.html",
 				"index.html",
+				"pkg/index.html",
 				"pkg/thing/index.html",
 				"pkg/thing/lib/index.html",
+				"src/index.html",
+				"src/thing/index.html",
+				"src/thing/lib/index.html",
 				"src/thing/lib/lib.go.html",
 				"src/thing/main.go.html",
 			}, fileNames)


### PR DESCRIPTION
* 016e032 Link branding to module package index
* 92817e6 Only show internal packages when navigating directly to them
* 57f500b Fix remaining missing src and pkg pages
* e028e9e Prepend base URL to source code page links
* bfdc469 Doc ignored gh-pages flags for watch command
* 2eea316 Add header info to getPage failures
* 84d1a19 Add file watcher and flags support to ./cmd/demo -> ./cmd/watch
* 8eff765 Move generators to separate internal package, run generate for demo script
