### PR TITLE
Add -source-link flag for custom source code link generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [pull_request]
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
 
 jobs:
   lint:

--- a/gopages/doc.go
+++ b/gopages/doc.go
@@ -24,6 +24,8 @@
 //     	The Git username to push with
 //   -out string
 //     	Output path for static files (default "dist")
+//   -source-link string
+//     	Custom source code link template. Disables built-in source code pages. For example, 'https://github.com/johnstarich/go/blob/master/gopages/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}' generates links compatible with GitHub and GitLab. Must be a valid Go template and must generate valid URLs.
 // 
 //
 package main

--- a/gopages/internal/flags/flags.go
+++ b/gopages/internal/flags/flags.go
@@ -3,18 +3,21 @@ package flags
 import (
 	"bytes"
 	"flag"
+
+	"github.com/johnstarich/go/gopages/internal/generate/source"
 )
 
 // Args contains all command-line options for gopages
 type Args struct {
-	BaseURL          string
-	GitHubPages      bool
-	GitHubPagesToken string
-	GitHubPagesUser  string
-	OutputPath       string
-	SiteDescription  string
-	SiteTitle        string
-	Watch            bool // not added as a flag, only enabled when running from ./cmd/watch
+	BaseURL            string
+	GitHubPages        bool
+	GitHubPagesToken   string
+	GitHubPagesUser    string
+	SourceLinkTemplate string
+	OutputPath         string
+	SiteDescription    string
+	SiteTitle          string
+	Watch              bool // not added as a flag, only enabled when running from ./cmd/watch
 }
 
 func Parse(osArgs ...string) (Args, string, error) {
@@ -24,6 +27,7 @@ func Parse(osArgs ...string) (Args, string, error) {
 	commandLine.StringVar(&args.BaseURL, "base", "", "Base URL to use for static assets")
 	commandLine.StringVar(&args.SiteTitle, "brand-title", "", "Branding title in the top left of documentation")
 	commandLine.StringVar(&args.SiteDescription, "brand-description", "", "Branding description in the top left of documentation")
+	commandLine.StringVar(&args.SourceLinkTemplate, "source-link", "", "Custom source code link template. Disables built-in source code pages. For example, 'https://github.com/johnstarich/go/blob/master/gopages/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}' generates links compatible with GitHub and GitLab. Must be a valid Go template and must generate valid URLs.")
 	commandLine.BoolVar(&args.GitHubPages, "gh-pages", false, "Automatically commit the output path to the gh-pages branch. The current branch must be clean.")
 	commandLine.StringVar(&args.GitHubPagesUser, "gh-pages-user", "", "The Git username to push with")
 	commandLine.StringVar(&args.GitHubPagesToken, "gh-pages-token", "", "The Git token to push with. Usually this is an API key.")
@@ -31,4 +35,11 @@ func Parse(osArgs ...string) (Args, string, error) {
 	commandLine.SetOutput(&output)
 	err := commandLine.Parse(osArgs) // prints usage if fails
 	return args, output.String(), err
+}
+
+func (a Args) Linker(modulePackage string) (source.Linker, error) {
+	if a.SourceLinkTemplate != "" {
+		return newTemplateLinker(modulePackage, a.SourceLinkTemplate)
+	}
+	return newGoPagesLinker(a.BaseURL), nil
 }

--- a/gopages/internal/flags/flags_test.go
+++ b/gopages/internal/flags/flags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParse(t *testing.T) {
@@ -14,4 +15,31 @@ func TestParse(t *testing.T) {
 	}, args)
 	assert.NotEmpty(t, output)
 	assert.Equal(t, flag.ErrHelp, err)
+}
+
+func TestArgsLinker(t *testing.T) {
+	const someBaseURL = "/some/base"
+
+	t.Run("default behavior - no template provided", func(t *testing.T) {
+		args := Args{
+			BaseURL:            someBaseURL,
+			SourceLinkTemplate: "",
+		}
+		linker, err := args.Linker("not used")
+		require.NoError(t, err)
+		assert.Equal(t, newGoPagesLinker(someBaseURL), linker)
+	})
+
+	t.Run("link template provided", func(t *testing.T) {
+		const someModulePackage = "github.com/org/repo"
+		args := Args{
+			BaseURL:            someBaseURL,
+			SourceLinkTemplate: "{{.Path}}#L{{.Line}}",
+		}
+		linker, err := args.Linker(someModulePackage)
+		require.NoError(t, err)
+		expectLinker, err := newTemplateLinker(someModulePackage, args.SourceLinkTemplate)
+		require.NoError(t, err)
+		assert.Equal(t, expectLinker, linker)
+	})
 }

--- a/gopages/internal/flags/linker.go
+++ b/gopages/internal/flags/linker.go
@@ -1,0 +1,82 @@
+package flags
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+	"text/template"
+
+	"github.com/johnstarich/go/gopages/internal/generate/source"
+)
+
+type GoPagesLinker struct {
+	baseURL string
+}
+
+func newGoPagesLinker(baseURL string) *GoPagesLinker {
+	return &GoPagesLinker{
+		baseURL: baseURL,
+	}
+}
+
+func (l *GoPagesLinker) LinkToSource(packagePath string, options source.LinkOptions) url.URL {
+	u := url.URL{
+		Path: path.Join(l.baseURL, "/src", packagePath),
+	}
+	if options.Line > 0 {
+		u.Fragment = fmt.Sprintf("L%d", options.Line)
+	}
+	return u
+}
+
+type TemplateLinker struct {
+	template      *template.Template
+	modulePackage string
+}
+
+var _ source.Linker = &TemplateLinker{}
+var _ source.ScrapeChecker = &TemplateLinker{}
+
+func newTemplateLinker(modulePackageURL, tmpl string) (*TemplateLinker, error) {
+	var l TemplateLinker
+	modulePackage, err := url.Parse(modulePackageURL)
+	if err == nil {
+		l.modulePackage = path.Join(modulePackage.Host, modulePackage.Path)
+		l.template, err = template.New("").Parse(tmpl)
+	}
+	return &l, err
+}
+
+func (l *TemplateLinker) LinkToSource(packagePath string, options source.LinkOptions) url.URL {
+	filePath := strings.TrimPrefix(packagePath, l.modulePackage)
+	filePath = strings.TrimPrefix(filePath, "/")
+	if filePath == packagePath {
+		return url.URL{}
+	}
+	var args = struct {
+		Path string
+		source.LinkOptions
+	}{
+		Path:        filePath,
+		LinkOptions: options,
+	}
+	var buf bytes.Buffer
+	err := l.template.Execute(&buf, args)
+	panicIfErr(err)
+	var u url.URL
+	err = u.UnmarshalBinary(buf.Bytes())
+	panicIfErr(err)
+	return u
+}
+
+func (l *TemplateLinker) ShouldScrapePackage(packagePath string) bool {
+	return strings.HasPrefix(packagePath, l.modulePackage+"/")
+}
+
+func panicIfErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/gopages/internal/flags/linker_test.go
+++ b/gopages/internal/flags/linker_test.go
@@ -1,0 +1,144 @@
+package flags
+
+import (
+	"errors"
+	"testing"
+	"text/template"
+
+	"github.com/johnstarich/go/gopages/internal/generate/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGoPagesLinker(t *testing.T) {
+	const someBaseURL = "/some/base"
+	linker := newGoPagesLinker(someBaseURL)
+	assert.Equal(t, &GoPagesLinker{baseURL: someBaseURL}, linker)
+}
+
+func TestGoPagesLinkToSource(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		baseURL     string
+		pkgPath     string
+		options     source.LinkOptions
+		expectLink  string
+	}{
+		{
+			description: "simple path",
+			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
+			expectLink:  "/src/github.com/org/repo/mypkg/myfile.go",
+		},
+		{
+			description: "base URL",
+			baseURL:     "/some/base",
+			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
+			expectLink:  "/some/base/src/github.com/org/repo/mypkg/myfile.go",
+		},
+		{
+			description: "line number",
+			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
+			options:     source.LinkOptions{Line: 10},
+			expectLink:  "/src/github.com/org/repo/mypkg/myfile.go#L10",
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			linker := newGoPagesLinker(tc.baseURL)
+			url := linker.LinkToSource(tc.pkgPath, tc.options)
+			assert.Equal(t, tc.expectLink, url.String())
+		})
+	}
+}
+
+func TestNewTemplateLinker(t *testing.T) {
+	const (
+		someModulePkg = "https://github.com/johnstarich/go"
+		someTemplate  = "https://github.com/johnstarich/go/blob/master/gopages/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}"
+	)
+	linker, err := newTemplateLinker(someModulePkg, someTemplate)
+	assert.NoError(t, err)
+	assert.Equal(t, &TemplateLinker{
+		modulePackage: "github.com/johnstarich/go",
+		template:      template.Must(template.New("").Parse(someTemplate)),
+	}, linker)
+}
+
+func TestTemplateLinkToSource(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		modulePkg   string
+		template    string
+		pkgPath     string
+		options     source.LinkOptions
+		expectLink  string
+	}{
+		{
+			description: "simple path",
+			modulePkg:   "github.com/org/repo",
+			template:    "{{.Path}}",
+			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
+			expectLink:  "mypkg/myfile.go",
+		},
+		{
+			description: "line number",
+			modulePkg:   "github.com/org/repo",
+			template:    "{{.Path}}#L{{.Line}}",
+			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
+			options:     source.LinkOptions{Line: 10},
+			expectLink:  "mypkg/myfile.go#L10",
+		},
+		{
+			description: "non-module path",
+			modulePkg:   "github.com/org/repo",
+			template:    "{{.Path}}#L{{.Line}}",
+			pkgPath:     "example.com/org/repo/mypkg/myfile.go",
+			expectLink:  "",
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			linker, err := newTemplateLinker(tc.modulePkg, tc.template)
+			require.NoError(t, err)
+			url := linker.LinkToSource(tc.pkgPath, tc.options)
+			assert.Equal(t, tc.expectLink, url.String())
+		})
+	}
+}
+
+func TestTemplateShouldScrapePackage(t *testing.T) {
+	for _, tc := range []struct {
+		description  string
+		modulePkg    string
+		pkgPath      string
+		expectScrape bool
+	}{
+		{
+			description:  "same package",
+			modulePkg:    "github.com/org/repo",
+			pkgPath:      "github.com/org/repo/mypkg/myfile.go",
+			expectScrape: true,
+		},
+		{
+			description:  "different package",
+			modulePkg:    "github.com/org/repo",
+			pkgPath:      "example.com/org/repo/mypkg/myfile.go",
+			expectScrape: false,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			linker, err := newTemplateLinker(tc.modulePkg, "")
+			require.NoError(t, err)
+			shouldScrape := linker.ShouldScrapePackage(tc.pkgPath)
+			assert.Equal(t, tc.expectScrape, shouldScrape)
+		})
+	}
+}
+
+func TestPanicIfErr(t *testing.T) {
+	assert.PanicsWithError(t, "some error", func() {
+		panicIfErr(errors.New("some error"))
+	})
+
+	assert.NotPanics(t, func() {
+		panicIfErr(nil)
+	})
+}

--- a/gopages/internal/generate/generate_test.go
+++ b/gopages/internal/generate/generate_test.go
@@ -60,7 +60,10 @@ package mylib
 	writeFile(".dotfile", `ignored dot file`)
 
 	args := flags.Args{}
-	err = Docs(thing, "github.com/my/thing", thingFS, outputFS, args)
+	const modulePackage = "github.com/my/thing"
+	linker, err := args.Linker(modulePackage)
+	require.NoError(t, err)
+	err = Docs(thing, modulePackage, thingFS, outputFS, args, linker)
 	assert.NoError(t, err)
 
 	expectedDocs := []string{

--- a/gopages/internal/generate/source/link.go
+++ b/gopages/internal/generate/source/link.go
@@ -1,0 +1,17 @@
+package source
+
+import (
+	"net/url"
+)
+
+type LinkOptions struct {
+	Line int
+}
+
+type Linker interface {
+	LinkToSource(packagePath string, options LinkOptions) url.URL
+}
+
+type ScrapeChecker interface {
+	ShouldScrapePackage(packagePath string) bool
+}

--- a/gopages/internal/module/module.go
+++ b/gopages/internal/module/module.go
@@ -1,0 +1,31 @@
+package module
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/johnstarich/go/gopages/internal/pipe"
+	"github.com/pkg/errors"
+	"golang.org/x/mod/modfile"
+)
+
+func Package(modulePath string) (string, error) {
+	goMod := filepath.Join(modulePath, "go.mod")
+	var modulePackage string
+	err := pipe.ChainFuncs(
+		func() error {
+			_, err := os.Stat(goMod)
+			return pipe.ErrIf(os.IsNotExist(err), errors.New("go.mod not found in the current directory"))
+		},
+		func() error {
+			buf, err := ioutil.ReadFile(goMod)
+			modulePackage = modfile.ModulePath(buf)
+			return err
+		},
+		func() error {
+			return pipe.ErrIf(modulePackage == "", errors.Errorf("Unable to find module package name in go.mod file: %s", goMod))
+		},
+	).Do()
+	return modulePackage, err
+}

--- a/gopages/internal/module/module_test.go
+++ b/gopages/internal/module/module_test.go
@@ -1,0 +1,14 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackage(t *testing.T) {
+	modulePackage, err := Package("../..")
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/johnstarich/go/gopages", modulePackage)
+}


### PR DESCRIPTION
Add `source.Linker` for custom source code link generation.
Enabled with the new `-source-link` Go template flag.

Fixes https://github.com/JohnStarich/go/issues/3