### PR TITLE
gopages: Encode page URLs instead of failable decoding

### DIFF
--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -217,13 +217,11 @@ func doRequest(do func(w http.ResponseWriter)) ([]byte, error) {
 }
 
 func getPage(pres *godoc.Presentation, path string) ([]byte, error) {
-	u, err := url.Parse(path)
-	if err != nil {
-		panic(err)
-	}
-	return doRequest(func(w http.ResponseWriter) {
+	u := &url.URL{Path: path}
+	respBody, err := doRequest(func(w http.ResponseWriter) {
 		pres.ServeHTTP(w, &http.Request{URL: u})
 	})
+	return respBody, err
 }
 
 func genericPage(pres *godoc.Presentation, title, body string) ([]byte, error) {

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -218,10 +218,9 @@ func doRequest(do func(w http.ResponseWriter)) ([]byte, error) {
 
 func getPage(pres *godoc.Presentation, path string) ([]byte, error) {
 	u := &url.URL{Path: path}
-	respBody, err := doRequest(func(w http.ResponseWriter) {
+	return doRequest(func(w http.ResponseWriter) {
 		pres.ServeHTTP(w, &http.Request{URL: u})
 	})
-	return respBody, err
 }
 
 func genericPage(pres *godoc.Presentation, title, body string) ([]byte, error) {

--- a/gopages/internal/generate/generate_test.go
+++ b/gopages/internal/generate/generate_test.go
@@ -58,6 +58,7 @@ package mylib
 `)
 	writeFile(".git/something", `ignored dot dir`)
 	writeFile(".dotfile", `ignored dot file`)
+	writeFile("%name.PascalCased%/other.go", `package bad_url_decode`)
 
 	args := flags.Args{}
 	const modulePackage = "github.com/my/thing"
@@ -71,6 +72,7 @@ package mylib
 		"index.html",
 		"pkg/github.com/index.html",
 		"pkg/github.com/my/index.html",
+		"pkg/github.com/my/thing/%name.PascalCased%/index.html", // Verifies fix for https://github.com/JohnStarich/go/issues/7
 		"pkg/github.com/my/thing/index.html",
 		"pkg/github.com/my/thing/internal/hello/index.html",
 		"pkg/github.com/my/thing/internal/index.html",
@@ -78,6 +80,8 @@ package mylib
 		"pkg/index.html",
 		"src/github.com/index.html",
 		"src/github.com/my/index.html",
+		"src/github.com/my/thing/%name.PascalCased%/index.html",
+		"src/github.com/my/thing/%name.PascalCased%/other.go.html",
 		"src/github.com/my/thing/index.html",
 		"src/github.com/my/thing/internal/hello/hello.go.html",
 		"src/github.com/my/thing/internal/hello/index.html",


### PR DESCRIPTION

Fixes an issue where paths that couldn't be URL decoded were failing to parse and panicking.

We don't even need to parse URLs in this scenario, so this change removes the error path entirely.

Fixes https://github.com/JohnStarich/go/issues/7
