### PR TITLE
Add pipe, a type-safe return-on-error pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a collection of my Go utilities in one easy-to-import and easy-to-share 
 * [dns](./dns): Implements a drop-in replacement for DNS, since Go's DNS on macOS doesn't always work
 * [gopages](./gopages): Generates static Go documentation, includes a GitHub Pages integration
 * [datasize](./datasize): Parse, format, and convert to differents units in bytes
+* [pipe](./pipe): Simplify error handling while keeping the original intent clear
 * [regext](./regext): Ignore whitespace and in-line comments in your regular expressions
 
 #### Questions? Concerns?

--- a/pipe/README.md
+++ b/pipe/README.md
@@ -1,0 +1,285 @@
+# pipe <a href="https://johnstarich.com/go/pipe"><img src="https://img.shields.io/badge/gopages-reference-%235272B4" /></a>
+
+Pipes handle errors so you don't have to.
+
+This means:
+* Verifying program correctness is easier
+* Fewer `if` branches makes the program simpler
+
+Want to get going? Jump to the [quick start](#quick-start).
+
+For more detail on how this works, read through [the approach](#more-rigorous-tests-with-less-effort) below.
+For full documentation, check out [the reference](https://johnstarich.com/go/pipe).
+
+**Caveat:** `Pipe`s should probably not be used _everywhere_. Instead, they should be used when stitching together many different failable functions. They're especially relevant when those functions are in a separate library.
+
+## Quick start
+
+A `Pipe` is a series of functions that pass data to one another, in-order. These functions can also fail with an error, which stops the flow and returns immediately.
+
+In this quick start, we'll create a pipe that returns true if the string argument parses to a positive integer.
+
+1. First, create a `Pipe` named `isPositive`. You can pass additional options for this pipe, but we'll use the defaults for now.
+```go
+import "github.com/johnstarich/go/pipe"
+
+isPositive := pipe.New(pipe.Options{}) // using default options
+```
+
+2. Append a function to convert from `args []interface{}` into the `string` we're expecting.
+```go
+isPositive = isPositive.Append(func(args []interface{}) string {
+    return args[0].(string) // for this example, just coerce the type
+})
+```
+
+Every time we append a function, the return types and parameter types must match. Then `Append()` returns a new Pipe with the added operation.
+
+3. Append a function to parse the previous string into an integer. The return types from the previous step become the new input types.
+```go
+isPositive = isPositive.Append(func(s string) (int64, error) {
+    return strconv.ParseInt(s, 10, 64)
+})
+```
+
+4. Finally, append a function to check if the integer is positive. Notice we didn't need to handle the error from the previous step.
+```go
+isPositive = isPositive.Append(func(i int64) bool {
+    return i > 0
+})
+```
+
+5. The pipe is ready to use. Let's run it.
+```go
+out, err := isPositive.Do("42")
+if err != nil {
+    panic(err)
+}
+positive := out[0].(bool)
+fmt.Println("42 is positive =", positive)
+// Output: 42 is positive = true
+```
+
+We covered a lot of ground there. Let's take a look at the full example:
+```go
+import "github.com/johnstarich/go/pipe"
+
+isPositive := pipe.New(pipe.Options{}).
+    Append(func(args []interface{}) string {
+	return args[0].(string) // convert to expected input types
+    }).
+    Append(func(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64) // parse input string to an integer
+    }).
+    Append(func(i int64) bool {
+	return i > 0 // check if it's positive
+    })
+
+out, err := isPositive.Do("42") // run with input "42"
+if err != nil {
+    panic(err)
+}
+positive := out[0].(bool)
+fmt.Println("42 is positive =", positive)
+// Output: 42 is positive = true
+```
+
+Our new pipeline is successfully checking a string is a positive integer!
+
+You may have noticed we didn't use an `if` statement to handle the `error` from `strconv.ParseInt()` -- that's important. By using a pipeline, that error handling is already taken care of.
+
+We'll go over why this is significant in the next section.
+
+## More rigorous tests with less effort
+
+`Pipe`s are heavily tested with known outcomes when functions return errors. Since internal `Pipe` behavior is fully vetted, it isn't necessary for us to write rigorous error path tests to achieve similar levels of correctness.
+
+By eliminating `if` branches in our own code, we're also eliminating branches we must test ourselves. The branches still exist, sure, but they only reside in `Pipe`'s built-in error handling, _which already has tests_.
+
+`Pipe`s help clean up code interacting with error-prone systems, like networks or files. In the below example, we reach out to `api.github.com`, read the body, parse it, and return the account creation date as a `time.Time`.
+
+```go
+var userCreatedDatePipe = pipe.New(pipe.Options{}).
+    // create the request
+    Append(func(args []interface{}) (*http.Request, error) {
+	ctx := args[0].(context.Context)
+	githubName := args[1].(string)
+        return http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/users/"+githubName, nil)
+    }).
+    // run the request
+    Append(http.DefaultClient.Do).
+    // verify success, return body reader
+    Append(func(resp *http.Response) (io.Reader, error) {
+	return resp.Body, pipe.CheckErrorf(resp.StatusCode != http.StatusOK, "fetch from api.github.com failed with status: %s", resp.Status)
+    }).
+    // read body
+    Append(ioutil.ReadAll).
+    // parse out created date
+    Append(func(body []byte) (string, error) {
+	var model struct {
+	    CreatedAt string `json:"created_at"`
+	}
+	err := json.Unmarshal(body, &model)
+	return model.CreatedAt, err
+    }).
+    // parse date into time.Time
+    Append(func(rawDate string) (time.Time, error) {
+	return time.Parse(time.RFC3339, rawDate)
+    })
+
+func UserCreatedDate(ctx context.Context, githubName string) (time.Time, error) {
+    out, err := userCreatedDatePipe.Do(ctx, githubName)
+    var createdDate time.Time
+    if err == nil {
+	createdDate = out[0].(time.Time)
+    }
+    return createdDate, err
+}
+
+name := "octocat"
+createdDate, err := UserCreatedDate(context.Background(), name)
+if err != nil {
+    panic(err)
+}
+fmt.Println("Account", name, "created on", createdDate.Format(time.Stamp))
+// Output:
+// Account octocat created on Jan 25 18:44:36
+```
+
+Pretty slick, eh?
+
+For comparison, see the traditional error handling approach below. Notice there are now several additional branches handling errors.
+
+Some of these errors can be difficult to hit in a test, making it difficult to verify correctness on every possible branch.
+
+```go
+func UserCreatedDate(ctx context.Context, githubName string) (time.Time, error) {
+    req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/users/"+githubName, nil)
+    if err != nil {
+	return time.Time{}, err
+    }
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+	return time.Time{}, err
+    }
+    if resp.StatusCode != http.StatusOK {
+	return time.Time{}, fmt.Errorf("fetch from api.github.com failed with status: %s", resp.Status)
+    }
+    defer resp.Body.Close()
+    body, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+	return time.Time{}, err
+    }
+
+    var model struct {
+	CreatedAt string `json:"created_at"`
+    }
+    err = json.Unmarshal(body, &model)
+    if err != nil {
+	return time.Time{}, err
+    }
+    return time.Parse(time.RFC3339, rawDate)
+}
+
+name := "octocat"
+createdDate, err := UserCreatedDate(context.Background(), name)
+if err != nil {
+    panic(err)
+}
+fmt.Println("Account", name, "created on", createdDate.Format(time.Stamp))
+```
+
+The difference may not be immediately obvious. Let's make it clearer by analyzing branch coverage of both programs.
+
+Assume we wrote 1 test for the success path using both Pipes and traditional error handling, then collected their test coverage results.
+
+Using Pipes with 1 success path test:
+```diff
+ var userCreatedDatePipe = pipe.New(pipe.Options{}).
+     Append(func(args []interface{}) (*http.Request, error) {
++	ctx := args[0].(context.Context)
++	githubName := args[1].(string)
++       return http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/users/"+githubName, nil)
+     }).
+     Append(http.DefaultClient.Do).
+     Append(func(resp *http.Response) (io.Reader, error) {
++	return resp.Body, pipe.CheckErrorf(resp.StatusCode != http.StatusOK, "fetch from api.github.com failed with status: %s", resp.Status)
+     }).
+     Append(ioutil.ReadAll).
+     Append(func(body []byte) (string, error) {
+ 	var model struct {
+ 	    CreatedAt string `json:"created_at"`
+ 	}
++	err := json.Unmarshal(body, &model)
++	return model.CreatedAt, err
+     }).
+     Append(func(rawDate string) (time.Time, error) {
++	return time.Parse(time.RFC3339, rawDate)
+     })
+ 
+ func UserCreatedDate(ctx context.Context, githubName string) (time.Time, error) {
++    out, err := userCreatedDatePipe.Do(ctx, githubName)
++    var createdDate time.Time
++    if err == nil {
++	createdDate = out[0].(time.Time)
+     }
++    return createdDate, err
+ }
+ 
+ name := "octocat"
+ createdDate, err := UserCreatedDate(context.Background(), name)
+ if err != nil {
+     panic(err)
+ }
+ fmt.Println("Account", name, "created on", createdDate.Format(time.Stamp))
+ // Output:
+ // Account octocat created on Jan 25 18:44:36
+```
+
+And now using traditional error handling with 1 success path test:
+```diff
+ func UserCreatedDate(ctx context.Context, githubName string) (time.Time, error) {
++    req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/users/"+githubName, nil)
++    if err != nil {
+-	return time.Time{}, err
+     }
++    resp, err := http.DefaultClient.Do(req)
++    if err != nil {
+-	return time.Time{}, err
+     }
++    if resp.StatusCode != http.StatusOK {
+-	return time.Time{}, fmt.Errorf("fetch from api.github.com failed with status: %s", resp.Status)
+     }
++    body, err := ioutil.ReadAll(resp.Body)
++    if err != nil {
+-	return time.Time{}, err
+     }
+ 
+     var model struct {
+ 	CreatedAt string `json:"created_at"`
+     }
++    err = json.Unmarshal(body, &model)
++    if err != nil {
+-	return time.Time{}, err
+     }
++    return time.Parse(time.RFC3339, rawDate)
+ }
+ 
+ name := "octocat"
+ createdDate, err := UserCreatedDate(context.Background(), name)
+ if err != nil {
+     panic(err)
+ }
+ fmt.Println("Account", name, "created on", createdDate.Format(time.Stamp))
+```
+
+The traditional approach using 1 test failed to cover all possible error paths. Normally this would require we write tests for every path to achieve full branch coverage and ensure 100% correctness.
+
+However, pipes can dramatically reduce the test effort and code complexity. The success path test we wrote covered every possible branch -- our code doesn't have any branches left to cover! *
+
+`Pipe`s simplify and test your code while keeping the original intent clear. Implemented well, they could completely eliminate whole classes of potential bugs.
+
+Questions or concerns? [Let us know what you think.](https://github.com/JohnStarich/go/issues/new)
+
+_* To be completely thorough, we may also want an error path test to cover the custom error message return value. That is left up to the reader._
+

--- a/pipe/error.go
+++ b/pipe/error.go
@@ -1,0 +1,17 @@
+package pipe
+
+import "fmt"
+
+func CheckError(cond bool, err error) error {
+	if cond {
+		return err
+	}
+	return nil
+}
+
+func CheckErrorf(cond bool, format string, args ...interface{}) error {
+	if cond {
+		return fmt.Errorf(format, args...)
+	}
+	return nil
+}

--- a/pipe/error.go
+++ b/pipe/error.go
@@ -1,6 +1,10 @@
 package pipe
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 func CheckError(cond bool, err error) error {
 	if cond {
@@ -14,4 +18,44 @@ func CheckErrorf(cond bool, format string, args ...interface{}) error {
 		return fmt.Errorf(format, args...)
 	}
 	return nil
+}
+
+type Error struct {
+	errs []error
+}
+
+func (e Error) Error() string {
+	if len(e.errs) == 1 {
+		return fmt.Sprintf("pipe: %v", e.errs[0])
+	}
+	errStrs := make([]string, len(e.errs))
+	for i, err := range e.errs {
+		errStrs[i] = err.Error()
+	}
+	return fmt.Sprintf("pipe: multiple errors: %s", strings.Join(errStrs, "; "))
+}
+
+// Unwrap implements errors.Unwrap() defined interface. Returns the first error only.
+func (e Error) Unwrap() error {
+	return e.errs[0]
+}
+
+// As implements errors.As() defined interface
+func (e Error) As(target interface{}) bool {
+	for _, candidate := range e.errs {
+		if errors.As(candidate, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// Is implements errors.Is() defined interface
+func (e Error) Is(target error) bool {
+	for _, candidate := range e.errs {
+		if errors.Is(candidate, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/pipe/error.go
+++ b/pipe/error.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// CheckError returns 'err' if 'cond' is true, nil otherwise
 func CheckError(cond bool, err error) error {
 	if cond {
 		return err
@@ -13,6 +14,7 @@ func CheckError(cond bool, err error) error {
 	return nil
 }
 
+// CheckErrorf returns a new formatted error if 'cond' is true, nil otherwise
 func CheckErrorf(cond bool, format string, args ...interface{}) error {
 	if cond {
 		return fmt.Errorf(format, args...)
@@ -20,10 +22,13 @@ func CheckErrorf(cond bool, format string, args ...interface{}) error {
 	return nil
 }
 
+// Error is an error returned from Pipe.Do().
+// Can contain 1 or more errors. Conforms to the standard library's errors package interfaces like errors.As().
 type Error struct {
 	errs []error
 }
 
+// Error implements the builtin error interface
 func (e Error) Error() string {
 	if len(e.errs) == 1 {
 		return fmt.Sprintf("pipe: %v", e.errs[0])

--- a/pipe/error_test.go
+++ b/pipe/error_test.go
@@ -1,0 +1,46 @@
+package pipe
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCheckError(t *testing.T) {
+	someErr := fmt.Errorf("some error")
+	if CheckError(true, someErr) == nil {
+		t.Error("Expected an error when cond is true")
+	}
+
+	if CheckError(false, someErr) != nil {
+		t.Error("Expected no error when cond is false")
+	}
+}
+
+func ExampleCheckError() {
+	isPositive := New().
+		Append(func(args []interface{}) (int, error) {
+			in, ok := args[0].(int)
+			return in + 1, CheckError(!ok, fmt.Errorf("not an int!"))
+		}).
+		Append(func(x int) bool {
+			return x > 0
+		})
+
+	_, err := isPositive.Do([]interface{}{"some string"})
+	fmt.Println(err)
+	// Output: not an int!
+}
+
+func TestCheckErrorf(t *testing.T) {
+	err := CheckErrorf(true, "some error %d", 1)
+	if err == nil {
+		t.Error("Expected an error when cond is true")
+	}
+	if err.Error() != "some error 1" {
+		t.Error("Unexpected error:", err)
+	}
+
+	if CheckErrorf(false, "some error %d", 1) != nil {
+		t.Fatal("Expected no error when cond is false")
+	}
+}

--- a/pipe/go.mod
+++ b/pipe/go.mod
@@ -1,3 +1,3 @@
 module github.com/johnstarich/go/pipe
 
-go 1.11
+go 1.13

--- a/pipe/go.mod
+++ b/pipe/go.mod
@@ -1,0 +1,3 @@
+module github.com/johnstarich/go/pipe
+
+go 1.11

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -1,0 +1,113 @@
+package pipe
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type Pipe struct {
+	ops []reflect.Value
+}
+
+func New() Pipe {
+	return Pipe{}
+}
+
+func (p Pipe) Do(args ...interface{}) ([]interface{}, error) {
+	argVals := []reflect.Value{reflect.ValueOf(args)}
+	for _, op := range p.ops {
+		var err error
+		argVals, err = splitErrValue(op.Call(argVals))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	resultVals := argVals
+	results := make([]interface{}, len(resultVals))
+	for i := range resultVals {
+		results[i] = resultVals[i].Interface()
+	}
+	return results, nil
+}
+
+func (p Pipe) Append(fn interface{}) Pipe {
+	p, err := p.appendFunc(fn)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+var interfaceSliceType = reflect.TypeOf([]interface{}{})
+
+func (p Pipe) appendFunc(fn interface{}) (Pipe, error) {
+	op := reflect.ValueOf(fn)
+	if op.Kind() != reflect.Func {
+		return p, fmt.Errorf("pipe value must a function, got: %T", fn)
+	}
+	if len(p.ops) == 0 {
+		opType := op.Type()
+		if opType.NumIn() != 1 || opType.In(0) != interfaceSliceType {
+			return p, fmt.Errorf("first pipe must accept 1 parameter of type []interface{}")
+		}
+	} else {
+		lastOp := p.ops[len(p.ops)-1]
+		if err := outMatchesIn(lastOp.Type(), op.Type()); err != nil {
+			return p, err
+		}
+	}
+	p.ops = append(p.ops, op)
+	return p, nil
+}
+
+func splitErrValue(args []reflect.Value) ([]reflect.Value, error) {
+	if len(args) == 0 {
+		return args, nil
+	}
+	lastVal := args[len(args)-1]
+	if !isErr(lastVal.Type()) {
+		return args, nil
+	}
+
+	errInt := lastVal.Interface()
+	var err error
+	if errInt != nil {
+		err = errInt.(error)
+	}
+	return args[:len(args)-1], err
+}
+
+var errType = reflect.TypeOf((*error)(nil)).Elem()
+
+func isErr(v reflect.Type) bool {
+	return v.Implements(errType)
+}
+
+func outMatchesIn(outFn, inFn reflect.Type) error {
+	var outTypes []reflect.Type
+	for i := 0; i < outFn.NumOut(); i++ {
+		outTypes = append(outTypes, outFn.Out(i))
+	}
+	var inTypes []reflect.Type
+	for i := 0; i < inFn.NumIn(); i++ {
+		inTypes = append(inTypes, inFn.In(i))
+	}
+
+	if len(outTypes) == len(inTypes)+1 && isErr(outTypes[len(outTypes)-1]) {
+		outTypes = outTypes[:len(outTypes)-1]
+	}
+
+	if len(outTypes) != len(inTypes) {
+		return fmt.Errorf("new function's parameter types do not match output function's return types: %v != %v", outTypes, inTypes)
+	}
+
+	for i := range outTypes {
+		out := outTypes[i]
+		in := inTypes[i]
+		if out != in {
+			return fmt.Errorf("new function's parameter type %v does not match the expected return type %v", in, out)
+		}
+	}
+	return nil
+}

--- a/pipe/pipe_test.go
+++ b/pipe/pipe_test.go
@@ -1,0 +1,198 @@
+package pipe
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestPipeData(t *testing.T) {
+	p := New().
+		Append(func([]interface{}) []int {
+			return []int{1, 2, 3}
+		}).
+		Append(func(v []int) ([]int, bool) {
+			sort.Sort(sort.Reverse(sort.IntSlice(v)))
+			return v, len(v) > 0
+		}).
+		Append(func(v []int, ok bool) bool {
+			return ok && v[0] == 3
+		})
+
+	out, err := p.Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Fatal("Out must have 1 return value, found:", len(out))
+	}
+	if out[0] != true {
+		t.Error("Return value must be true, found:", out[0])
+	}
+}
+
+func TestPipeErr(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		p := New().
+			Append(func([]interface{}) ([]int, error) {
+				return nil, fmt.Errorf("failed")
+			}).
+			Append(func(v []int) ([]int, bool) {
+				sort.Sort(sort.Reverse(sort.IntSlice(v)))
+				return v, len(v) > 0
+			})
+
+		out, err := p.Do([]int{1, 2, 3})
+		if err == nil {
+			t.Fatal("Expected err, got nil")
+		}
+		if out != nil {
+			t.Error("Out must be unset")
+		}
+		if err.Error() != "failed" {
+			t.Error("Unexpected error message:", err.Error())
+		}
+	})
+
+	t.Run("no error", func(t *testing.T) {
+		p := New().
+			Append(func([]interface{}) []int {
+				return []int{1, 2, 3}
+			}).
+			Append(func(v []int) ([]int, error) {
+				return v, nil
+			}).
+			Append(func(v []int) ([]int, bool) {
+				sort.Sort(sort.Reverse(sort.IntSlice(v)))
+				return v, len(v) > 0
+			})
+
+		out, err := p.Do()
+		if err != nil {
+			t.Fatal("Expected no err, got:", err)
+		}
+		if len(out) != 2 {
+			t.Fatal("Out must have 2 return values, found:", len(out))
+		}
+		if !reflect.DeepEqual(out[0], []int{3, 2, 1}) {
+			t.Error("Return value 0 must be [3, 2, 1], found:", out[0])
+		}
+		if out[1] != true {
+			t.Error("Return value 1 must be true, found:", out[1])
+		}
+	})
+}
+
+func TestPipeInvalid(t *testing.T) {
+	t.Run("mismatched output and input types", func(t *testing.T) {
+		assertPanics(t,
+			fmt.Errorf("new function's parameter type bool does not match the expected return type []int"),
+			func() {
+				New().
+					Append(func([]interface{}) []int {
+						return nil
+					}).
+					Append(func(v bool) bool {
+						return v
+					})
+			})
+	})
+
+	t.Run("missing input param", func(t *testing.T) {
+		assertPanics(t,
+			fmt.Errorf("new function's parameter types do not match output function's return types: [[]int] != []"),
+			func() {
+				New().
+					Append(func([]interface{}) []int {
+						return nil
+					}).
+					Append(func() bool {
+						return false
+					})
+			})
+	})
+
+	t.Run("zero return values and zero params", func(t *testing.T) {
+		p := New().
+			Append(func([]interface{}) {}).
+			Append(func() bool {
+				return false
+			})
+		out, err := p.Do()
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+		if !reflect.DeepEqual(out, []interface{}{false}) {
+			t.Error("Unexpected out:", out)
+		}
+	})
+
+	t.Run("not a function", func(t *testing.T) {
+		assertPanics(t,
+			fmt.Errorf("pipe value must a function, got: string"),
+			func() {
+				New().
+					Append("not a func")
+			})
+	})
+
+	t.Run("first pipe must accept args", func(t *testing.T) {
+		assertPanics(t,
+			fmt.Errorf("first pipe must accept 1 parameter of type []interface{}"),
+			func() {
+				New().
+					Append(func() {})
+			})
+	})
+}
+
+func assertPanics(t *testing.T, value interface{}, fn func()) {
+	t.Helper()
+	defer func() {
+		v := recover()
+		shouldPanic := value != nil
+		if (v != nil) != shouldPanic {
+			if shouldPanic {
+				t.Error("Expected panic")
+			} else {
+				t.Error("Unexpected panic")
+			}
+		}
+		if shouldPanic && !reflect.DeepEqual(v, value) {
+			t.Errorf("Unexpected panic value: %v != %v", v, value)
+		}
+	}()
+	fn()
+}
+
+func TestPipeReuse(t *testing.T) {
+	p := New().
+		Append(func([]interface{}) string {
+			return "hello"
+		})
+
+	p1 := p.Append(func(s string) string {
+		return s + " world"
+	})
+
+	p2 := p.Append(func(s string) string {
+		return s + " universe"
+	})
+
+	out1, err := p1.Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]interface{}{"hello world"}, out1) {
+		t.Error("Unexpected p1 output:", out1)
+	}
+
+	out2, err := p2.Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]interface{}{"hello universe"}, out2) {
+		t.Error("Unexpected p2 output:", out2)
+	}
+}


### PR DESCRIPTION
Adds a new module named `pipe`. Pipe implements a pattern I've used several times before, so this merely formalizes it.

Previous uses in open source:
* https://github.com/JohnStarich/go/blob/614c33c963c789a54cf5886732d23d241c5bd55b/gopages/internal/generate/generate.go#L33
* https://github.com/JohnStarich/sage/blob/0826da3a31b6a83f4f17444a382265be8d55a718/vcs/vcs.go#L50

Previous [blog post](https://johnstarich.medium.com/ive-been-thinking-about-trying-something-like-this-too-i-like-your-approach-d6338256bd9) about the concept, too.