### PR TITLE
Adding Port to resolver struct.

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -93,8 +93,12 @@ func (m *macOSDialer) ensureNameservers() ([]string, error) {
 	m.Logger.Info("Reading macOS DNS config from 'scutil'...")
 	cfg, err := m.readResolvers(ctx)
 	for _, resolver := range cfg.Resolvers {
+		port := resolver.Port
+		if port == "" {
+			port = "53"
+		}
 		for _, nameserver := range resolver.Nameservers {
-			m.nameservers = append(m.nameservers, dialableNameserver(nameserver)+":53")
+			m.nameservers = append(m.nameservers, dialableNameserver(nameserver)+":"+port)
 		}
 	}
 	m.Logger.Info("Finished reading macOS DNS config from 'scutil'", zap.Error(err))

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -94,11 +94,11 @@ func (m *macOSDialer) ensureNameservers() ([]string, error) {
 	cfg, err := m.readResolvers(ctx)
 	for _, resolver := range cfg.Resolvers {
 		port := resolver.Port
-		if port == "" {
-			port = "53"
+		if port == 0 {
+			port = 53
 		}
 		for _, nameserver := range resolver.Nameservers {
-			m.nameservers = append(m.nameservers, dialableNameserver(nameserver)+":"+port)
+			m.nameservers = append(m.nameservers, dialableNameserver(nameserver)+":"+fmt.Sprint(port))
 		}
 	}
 	m.Logger.Info("Finished reading macOS DNS config from 'scutil'", zap.Error(err))

--- a/dns/scutil/config.go
+++ b/dns/scutil/config.go
@@ -24,7 +24,7 @@ type Resolver struct {
 	MulticastDNS   bool
 	Nameservers    []string
 	Order          int
-	Port           string
+	Port           int
 	Reach          []Reach
 	reachable      bool // cached status from Reach
 	SearchDomain   []string
@@ -83,7 +83,10 @@ func readMacOSDNS(ctx context.Context, getSCUtilDNS scutilExecutor) (Config, err
 		case strings.Contains(key, "options"):
 			currentResolver.MulticastDNS = strings.Contains(value, "mdns")
 		case strings.Contains(key, "port"):
-			currentResolver.Port = value
+			i, err := strconv.ParseInt(value, 10, 64)
+			if err == nil {
+				currentResolver.Port = int(i)
+			}
 		case strings.Contains(key, "nameserver"):
 			currentResolver.Nameservers = append(currentResolver.Nameservers, value)
 		case strings.Contains(key, "order"):

--- a/dns/scutil/config.go
+++ b/dns/scutil/config.go
@@ -24,6 +24,7 @@ type Resolver struct {
 	MulticastDNS   bool
 	Nameservers    []string
 	Order          int
+	Port           string
 	Reach          []Reach
 	reachable      bool // cached status from Reach
 	SearchDomain   []string
@@ -81,6 +82,8 @@ func readMacOSDNS(ctx context.Context, getSCUtilDNS scutilExecutor) (Config, err
 			}
 		case strings.Contains(key, "options"):
 			currentResolver.MulticastDNS = strings.Contains(value, "mdns")
+		case strings.Contains(key, "port"):
+			currentResolver.Port = value
 		case strings.Contains(key, "nameserver"):
 			currentResolver.Nameservers = append(currentResolver.Nameservers, value)
 		case strings.Contains(key, "order"):

--- a/dns/scutil/config_test.go
+++ b/dns/scutil/config_test.go
@@ -146,6 +146,14 @@ resolver #3
   reach    : 0x00000000 (Not Reachable)
   order    : 300600
 
+resolver #4
+  domain   : 10.in-addr.arpa
+  nameserver[0] : 127.0.0.1
+  port     : 8600
+  timeout  : 5
+  flags    : Request A records, Request AAAA records
+  reach    : 0x00030002 (Reachable,Local Address,Directly Reachable Address)
+
 DNS configuration (for scoped queries)
 
 resolver #1
@@ -186,6 +194,15 @@ resolver #2
 					Flags:        []Flag{RequestARecords},
 					Reach:        []Reach{NotReachable},
 					Order:        300600,
+				},
+				{
+					Domain:      "10.in-addr.arpa",
+					Port:        "8600",
+					Nameservers: []string{"127.0.0.1"},
+					Timeout:     5 * time.Second,
+					Flags:       []Flag{RequestARecords, RequestAAAARecords},
+					Reach:       []Reach{Reachable, LocalAddress, DirectlyReachableAddress},
+					reachable:   true,
 				},
 				{
 					Nameservers:    []string{"8.8.8.8", "8.8.4.4"},

--- a/dns/scutil/config_test.go
+++ b/dns/scutil/config_test.go
@@ -197,7 +197,7 @@ resolver #2
 				},
 				{
 					Domain:      "10.in-addr.arpa",
-					Port:        "8600",
+					Port:        8600,
 					Nameservers: []string{"127.0.0.1"},
 					Timeout:     5 * time.Second,
 					Flags:       []Flag{RequestARecords, RequestAAAARecords},


### PR DESCRIPTION
Hi ,

This PR is an attempt to add the port to the resolvers struct. I use a domain specific resolver that runs on a non-standard port and I use a file like the following to tell my system how to reach it.

`/etc/resolver/10.in-addr.arpa`
```
nameserver 127.0.0.1
port 8600
timeout 5
```

from man resolver(5)

_Also, I understand this code is probably rubbish so if you decide to implement it another way I won't be offended._