### PR TITLE
Add Go test for multiple versions, including latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,22 +8,45 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    name: Lint
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Lint
       run: make lint
 
-  test:
+  test-coverage:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16.x
+    name: Test with Go ${{ matrix.go }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go }}
     - name: Test
       run: make test
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.17.x
+          - ^1.18  # Latest version of Go
+    name: Test with Go ${{ matrix.go }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
+        check_latest: true
+    - name: Test
+      run: make test


### PR DESCRIPTION
Looks like Go 1.18 caused some [issues](https://github.com/JohnStarich/go/pull/15) compiling `gopages`. This PR adds more Go versions so we're more likely to catch those early.