### PR TITLE
gopages: Fix default source links not including `.html` extension

### DIFF
--- a/gopages/internal/flags/linker.go
+++ b/gopages/internal/flags/linker.go
@@ -27,6 +27,9 @@ func (l *GoPagesLinker) LinkToSource(packagePath string, options source.LinkOpti
 	u := url.URL{
 		Path: path.Join(l.baseURL, "/src", packagePath),
 	}
+	if path.Ext(u.Path) == ".go" {
+		u.Path += ".html"
+	}
 	if options.Line > 0 {
 		u.Fragment = fmt.Sprintf("L%d", options.Line)
 	}

--- a/gopages/internal/flags/linker_test.go
+++ b/gopages/internal/flags/linker_test.go
@@ -29,19 +29,19 @@ func TestGoPagesLinkToSource(t *testing.T) {
 		{
 			description: "simple path",
 			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
-			expectLink:  "/src/github.com/org/repo/mypkg/myfile.go",
+			expectLink:  "/src/github.com/org/repo/mypkg/myfile.go.html",
 		},
 		{
 			description: "base URL",
 			baseURL:     "/some/base",
 			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
-			expectLink:  "/some/base/src/github.com/org/repo/mypkg/myfile.go",
+			expectLink:  "/some/base/src/github.com/org/repo/mypkg/myfile.go.html",
 		},
 		{
 			description: "line number",
 			pkgPath:     "github.com/org/repo/mypkg/myfile.go",
 			options:     source.LinkOptions{Line: 10},
-			expectLink:  "/src/github.com/org/repo/mypkg/myfile.go#L10",
+			expectLink:  "/src/github.com/org/repo/mypkg/myfile.go.html#L10",
 		},
 	} {
 		tc := tc // enable parallel sub-tests

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -86,7 +86,6 @@ var makePresentationPipe = pipe.New(pipe.Options{}).
 			return mode
 		}
 		// attempt to override URLs for source code links
-		// TODO fix links from source pages back to docs
 		pres.URLForSrc = func(src string) string {
 			// seems godoc lib documentation is incorrect here, 'src' is actually the whole package path to the file
 			src = strings.TrimPrefix(src, "/")


### PR DESCRIPTION

Fixes default source links not including `.html` extension.

Fixes a related issue mentioned in both https://github.com/JohnStarich/go/issues/25 and https://github.com/JohnStarich/go/issues/27
