### PR TITLE
gopages: Generate docs with internal packages

### DIFF
--- a/gopages/doc.go
+++ b/gopages/doc.go
@@ -29,6 +29,11 @@
 //	-include-head value
 //	  	Includes the given HTML file's contents in every page's '<head></head>'. Useful
 //	  	for including custom analytics scripts. Must be valid HTML.
+//	-internal
+//	  	Includes 'internal' packages in the package index and unexported functions.
+//	  	Useful for sharing documentation within the same development team. Note: This
+//	  	only affects page generation for non-internal packages, like package lists.
+//	  	Internal package docs are always generated.
 //	-out string
 //	  	Output path for static files (default "dist")
 //	-source-link string

--- a/gopages/internal/flags/flags.go
+++ b/gopages/internal/flags/flags.go
@@ -10,16 +10,17 @@ import (
 
 // Args contains all command-line options for gopages
 type Args struct {
-	BaseURL            string
-	GitHubPages        bool
-	GitHubPagesToken   string
-	GitHubPagesUser    string
-	IncludeInHead      FilePathContents
-	SourceLinkTemplate string
-	OutputPath         string
-	SiteDescription    string
-	SiteTitle          string
-	Watch              bool // not added as a flag, only enabled when running from ./cmd/watch
+	BaseURL               string
+	GitHubPages           bool
+	GitHubPagesToken      string
+	GitHubPagesUser       string
+	IncludeInHead         FilePathContents
+	IndexInternalPackages bool
+	SourceLinkTemplate    string
+	OutputPath            string
+	SiteDescription       string
+	SiteTitle             string
+	Watch                 bool // not added as a flag, only enabled when running from ./cmd/watch
 }
 
 // Parse parses the given command line arguments into Args values and returns any output to send to the user
@@ -32,6 +33,7 @@ func Parse(osArgs ...string) (Args, string, error) {
 	commandLine.StringVar(&args.SiteDescription, "brand-description", "", "Branding description in the top left of documentation")
 	commandLine.StringVar(&args.SourceLinkTemplate, "source-link", "", `Custom source code link template. Disables built-in source code pages. For example, "https://github.com/johnstarich/go/blob/master/gopages/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}" generates links compatible with GitHub and GitLab. Must be a valid Go template and must generate valid URLs.`)
 	commandLine.Var(&args.IncludeInHead, "include-head", "Includes the given HTML file's contents in every page's '<head></head>'. Useful for including custom analytics scripts. Must be valid HTML.")
+	commandLine.BoolVar(&args.IndexInternalPackages, "internal", false, "Includes 'internal' packages in the package index and unexported functions. Useful for sharing documentation within the same development team. Note: This only affects page generation for non-internal packages, like package lists. Internal package docs are always generated.")
 
 	commandLine.BoolVar(&args.GitHubPages, "gh-pages", false, "Automatically commit the output path to the gh-pages branch. The current branch must be clean.")
 	commandLine.StringVar(&args.GitHubPagesUser, "gh-pages-user", "", "The Git username to push with")

--- a/gopages/internal/generate/generate.go
+++ b/gopages/internal/generate/generate.go
@@ -101,7 +101,9 @@ var makePresentationPipe = pipe.New(pipe.Options{}).
 		pres := godoc.NewPresentation(corpus)
 		pres.AdjustPageInfoMode = func(req *http.Request, mode godoc.PageInfoMode) godoc.PageInfoMode {
 			switch {
-			case req.URL.Path == "/pkg/", strings.HasPrefix(req.URL.Path, "/pkg/") && strings.HasSuffix(req.URL.Path, "/internal/"):
+			case args.IndexInternalPackages,
+				req.URL.Path == "/pkg/",
+				strings.HasPrefix(req.URL.Path, "/pkg/") && strings.HasSuffix(req.URL.Path, "/internal/"):
 				mode |= godoc.NoFiltering
 			}
 			return mode

--- a/gopages/internal/generate/generate_test.go
+++ b/gopages/internal/generate/generate_test.go
@@ -158,7 +158,8 @@ func Hello() {
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			// create a new package "thing" and generate docs for it
-			thing := t.TempDir()
+			thing, err := os.MkdirTemp("", "")
+			require.NoError(t, err)
 			require.NoError(t, os.Chdir(thing))
 			t.Cleanup(func() {
 				os.RemoveAll(thing)


### PR DESCRIPTION

Generate docs with internal packages. I'm not sure what is different today compared to last year in #6, but the internal package indexes are working now!

Fixes https://github.com/JohnStarich/go/issues/6
