### PR TITLE
gopages: Add note to use Go 1.19+ for improved formatting

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,10 +10,10 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.19.x
     - name: Deploy Docs
       run: make deploy-docs
       env:

--- a/gopages/cmd/gendoc/doc.go
+++ b/gopages/cmd/gendoc/doc.go
@@ -9,6 +9,9 @@
 //   cd ./mymodule
 //   gopages
 //
+// NOTE: Install gopages with Go v1.19 or higher to generate documentation with custom links, lists, headings, and more.
+// See: https://pkg.go.dev/go/doc/comment
+//
 // {{.Usage | wordWrap 80 | comment}}
 // {{- /* Do not remove the blank line below, otherwise this template is incorrectly displayed for the cmd/gendoc package. */}}
 

--- a/gopages/cmd/gendoc/doc.go
+++ b/gopages/cmd/gendoc/doc.go
@@ -1,16 +1,21 @@
-// gopages generates static files for Go documentation, formatted with godoc.
+// Command gopages generates static files for Go documentation, formatted with godoc.
 //
-// Installation:
-//   go get github.com/johnstarich/go/gopages
+// # Installation
 //
-// Generate documentation for your module by running without any flags.
+// To install gopages, run the following command:
+//   go install github.com/johnstarich/go/gopages@latest
+//
+// # Getting started
+//
+// Generate documentation for your module by running gopages without any flags.
 //
 // A 'go.mod' file must be present in the current directory.
 //   cd ./mymodule
 //   gopages
 //
-// NOTE: Install gopages with Go v1.19 or higher to generate documentation with custom links, lists, headings, and more.
-// See: https://pkg.go.dev/go/doc/comment
+// NOTE: Install gopages with Go v1.19 or higher to generate documentation with [improved formatting].
+//
+// [improved formatting]: https://pkg.go.dev/go/doc/comment
 //
 // {{.Usage | wordWrap 80 | comment}}
 // {{- /* Do not remove the blank line below, otherwise this template is incorrectly displayed for the cmd/gendoc package. */}}

--- a/gopages/doc.go
+++ b/gopages/doc.go
@@ -1,18 +1,21 @@
-// gopages generates static files for Go documentation, formatted with godoc.
+// Command gopages generates static files for Go documentation, formatted with godoc.
 //
-// Installation:
+// # Installation
 //
-//	go get github.com/johnstarich/go/gopages
+// To install gopages, run the following command:
 //
-// Generate documentation for your module by running without any flags.
+//	go install github.com/johnstarich/go/gopages@latest
+//
+// # Getting started
+//
+// Generate documentation for your module by running gopages without any flags.
 //
 // A 'go.mod' file must be present in the current directory.
 //
 //	cd ./mymodule
 //	gopages
 //
-// NOTE: Install gopages with Go v1.19 or higher to generate documentation with custom links, lists, headings, and more.
-// See: https://pkg.go.dev/go/doc/comment
+// NOTE: Install gopages with Go v1.19 or higher to generate documentation with [improved formatting].
 //
 // Usage of gopages:
 //
@@ -44,4 +47,6 @@
 //	  	example, "https://github.com/johnstarich/go/blob/master/gopages/{{.Path}}{{if .Line}}#L{{.Line}}{{end}}"
 //	  	generates links compatible with GitHub and GitLab. Must be a valid Go template
 //	  	and must generate valid URLs.
+//
+// [improved formatting]: https://pkg.go.dev/go/doc/comment
 package main

--- a/gopages/doc.go
+++ b/gopages/doc.go
@@ -11,6 +11,9 @@
 //	cd ./mymodule
 //	gopages
 //
+// NOTE: Install gopages with Go v1.19 or higher to generate documentation with custom links, lists, headings, and more.
+// See: https://pkg.go.dev/go/doc/comment
+//
 // Usage of gopages:
 //
 //	-base string


### PR DESCRIPTION
Add docs note to generate with Go 1.19+ for improved HTML formatting. Pretty up gopages docs a bit.
