### PR TITLE
dns: Mark module as obsolete as of Go 1.20

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -1,5 +1,7 @@
 # dns <a href="https://johnstarich.com/go/dns"><img src="https://img.shields.io/badge/gopages-reference-%235272B4" /></a>
 
+**NOTE:** This module is obsolete as of Go 1.20. Go now uses the [native macOS DNS resolver][golang-issue]!
+
 Implements a working macOS DNS resolver (really just a `Dial`er) for projects that must cross-compile from Linux systems or just don't want CGO.
 
 In my experience, it is common to disable CGO for macOS CI builds. However, there's been a [few issues with that][golang-issue]. This library adds a drop-in replacement for Go's `net.DefaultResolver` to fill the gap.


### PR DESCRIPTION
Obsolete as of https://github.com/golang/go/issues/12524
